### PR TITLE
Stop timestamps too far in future

### DIFF
--- a/TrophyIsBetter/ViewModels/EditTimestampViewModel.cs
+++ b/TrophyIsBetter/ViewModels/EditTimestampViewModel.cs
@@ -1,10 +1,11 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System;
+using System.ComponentModel;
 using System.Windows.Input;
 
 namespace TrophyIsBetter.ViewModels
 {
-  public class EditTimestampViewModel : ObservableObject
+  public class EditTimestampViewModel : ObservableObject, IDataErrorInfo
   {
     #region Private Members
 
@@ -26,8 +27,57 @@ namespace TrophyIsBetter.ViewModels
     /// </summary>
     public ICommand OnConfirmCommand { get; set; }
 
-    public DateTime Timestamp { get => _timestamp; set => SetProperty(ref _timestamp, value); }
+    public DateTime Timestamp
+    {
+      get => _timestamp;
+      set
+      {
+        SetProperty(ref _timestamp, value);
+      }
+    }
+
+    public DateTime DateTimestamp
+    {
+      get => Timestamp;
+      set
+      {
+        Timestamp = value.AddHours(Timestamp.Hour)
+                         .AddMinutes(Timestamp.Minute)
+                         .AddSeconds(Timestamp.Second);
+      }
+    }
+
+    public string Error => throw new NotImplementedException();
+    public string this[string propertyName] => IsValid(propertyName);
 
     #endregion Public Properties
-  } // EditTimestampViewModel
+    #region Private Methods
+
+    private string IsValid(string propertyName)
+    {
+      string result = "";
+
+      switch (propertyName)
+      {
+        case "Timestamp":
+        case "DateTimestamp":
+          result = ValidateTimestamp();
+          break;
+      }
+
+      return result;
+    } // IsValid
+
+    private string ValidateTimestamp()
+    {
+      string result = "";
+
+      if (DateTime.Compare(Timestamp, DateTime.UtcNow.AddHours(14)) > 0)
+        result = "Too far in future, max 14 hours";
+
+      return result;
+    } // ValidateTimestamp
+
+      #endregion Private Methods
+    } // EditTimestampViewModel
 } // TrophyIsBetter.ViewModels

--- a/TrophyIsBetter/Views/EditTimestampWindow.xaml
+++ b/TrophyIsBetter/Views/EditTimestampWindow.xaml
@@ -13,26 +13,28 @@
         Background="{DynamicResource MaterialDesignPaper}"
         FontFamily="{materialDesign:MaterialDesignFont}"
         Title="Edit Timestamp"
-        Height="130"
+        Height="145"
         Width="210">
 
   <StackPanel Margin="10">
     <StackPanel x:Name="PickerPanel"
                 Orientation="Horizontal">
-      <DatePicker SelectedDate="{Binding Timestamp}"
+      <DatePicker SelectedDate="{Binding DateTimestamp,
+                                         ValidatesOnDataErrors=True}"
                   Width="90"/>
-      <materialDesign:TimePicker SelectedTime="{Binding Timestamp}"
+      <materialDesign:TimePicker SelectedTime="{Binding Timestamp,
+                                                        ValidatesOnDataErrors=True}"
                                  Is24Hours="True"
                                  WithSeconds="True"
                                  Width="75"
-                                 Margin="10,0,0,0"/>
+                                 Margin="10,0,0,0">
+      </materialDesign:TimePicker>
     </StackPanel>
 
     <Button Content="Confirm"
-            ToolTip="MaterialDesignFlatDarkButton"
             IsDefault="True"
             Click="Confirm_Click"
             Style="{StaticResource MaterialDesignFlatDarkBgButton}"
-            Margin="0,10,0,0"/>
+            Margin="0,30,0,0"/>
   </StackPanel>
 </Window>


### PR DESCRIPTION
The earliest timezone is UTC+14. Just to be safe block unlocking trophies any further in to the future.

Closest #26 