### PR TITLE
Customise copy from timestamps

### DIFF
--- a/TrophyIsBetter/ViewModels/GameViewModel.cs
+++ b/TrophyIsBetter/ViewModels/GameViewModel.cs
@@ -186,6 +186,7 @@ namespace TrophyIsBetter.ViewModels
       else
       {
         _model.Reload();
+        LoadTrophies();
       }
     } // Save
 
@@ -273,6 +274,7 @@ namespace TrophyIsBetter.ViewModels
         {
           _model.UnlockTrophy(trophy.Model, trophy.RemoteTimestamp.Value);
 
+          trophy.Timestamp = trophy.RemoteTimestamp.Value;
           trophy.RemoteTimestamp = null;
           trophy.ShouldCopy = false;
         }

--- a/TrophyIsBetter/ViewModels/GameViewModel.cs
+++ b/TrophyIsBetter/ViewModels/GameViewModel.cs
@@ -191,7 +191,7 @@ namespace TrophyIsBetter.ViewModels
 
     private void EditTrophy()
     {
-      EditTimestampWindow window = new EditTimestampWindow
+      EditTimestampWindow window = new EditTimestampWindow("Edit Timestamp")
       {
         DataContext = new EditTimestampViewModel(_lastUsedTimestamp ?? DateTime.Now)
       };

--- a/TrophyIsBetter/Views/CopyFromWindow.xaml
+++ b/TrophyIsBetter/Views/CopyFromWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         mc:Ignorable="d"
         TextElement.Foreground="{DynamicResource MaterialDesignBody}"
         TextElement.FontWeight="Regular"
@@ -46,13 +47,20 @@
             DockPanel.Dock="Bottom"
             VerticalAlignment="Bottom"/>
 
-    <ListView ItemsSource="{Binding TrophyCollection}"
+    <ListView ItemsSource="{Binding TrophyCollectionView}"
+              IsSynchronizedWithCurrentItem="True"
               DockPanel.Dock="Top"
               Height="auto"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch"
               Margin="0,10"
               d:ItemsSource="{d:SampleData ItemCount=25}">
+      <i:Interaction.Triggers>
+        <i:EventTrigger EventName="MouseDoubleClick">
+          <i:InvokeCommandAction Command="{Binding UpdateTimestampsCommand}" />
+        </i:EventTrigger>
+      </i:Interaction.Triggers>
+      
       <ListView.View>
         <GridView>
           <GridViewColumn Header="Name"

--- a/TrophyIsBetter/Views/CopyFromWindow.xaml
+++ b/TrophyIsBetter/Views/CopyFromWindow.xaml
@@ -26,7 +26,7 @@
                VerticalAlignment="Top"
                HorizontalAlignment="Stretch">
       <Button Content="{materialDesign:PackIcon CloudDownload}"
-              Command="{Binding DownloadTimestampsCommand}"
+              Command="{Binding GetTimestampsCommand}"
               DockPanel.Dock="Right"
               HorizontalAlignment="Right"/>
       <TextBox x:Name="UrlTextbox"
@@ -51,7 +51,8 @@
               Height="auto"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch"
-              Margin="0,10">
+              Margin="0,10"
+              d:ItemsSource="{d:SampleData ItemCount=25}">
       <ListView.View>
         <GridView>
           <GridViewColumn Header="Name"

--- a/TrophyIsBetter/Views/EditTimestampWindow.xaml.cs
+++ b/TrophyIsBetter/Views/EditTimestampWindow.xaml.cs
@@ -9,9 +9,11 @@ namespace TrophyIsBetter.Views
   {
     #region Constructors
 
-    public EditTimestampWindow()
+    public EditTimestampWindow(string title)
     {
       InitializeComponent();
+
+      Title = title;
     } // Constructor
 
     #endregion Constructors


### PR DESCRIPTION
When downloading timestamps, users will now be prompted to choose a starting timestamp. All timestamps will be changed by the same offset.

When editing a remote timestamp that is not the starting remote timestamp, any timestamps with a later time than the one that has been edited will be changed by the same offset.

Closes #50 (Change of plan)