### PR TITLE
Fix PS3 ID saving

### DIFF
--- a/TrophyParser/PS3/Structs.cs
+++ b/TrophyParser/PS3/Structs.cs
@@ -618,6 +618,7 @@ namespace TrophyParser.PS3
         padding = new byte[16];
         padding2 = new byte[96];
         Time = dt;
+        DoesExist = true;
       }
     } // EarnedInfo
 

--- a/TrophyParser/PS3/TROPTRNS.cs
+++ b/TrophyParser/PS3/TROPTRNS.cs
@@ -222,7 +222,7 @@ namespace TrophyParser.PS3
         info.ID = i + 1;
         info._unknownInt3 = 0;
 
-        //_timestamps[i] = info;
+        _timestamps[i] = info;
         writer.Write(_timestamps[i].StructToBytes());
       }
 


### PR DESCRIPTION
Trophy ID is not being saved correctly along with timestamp data.